### PR TITLE
Previous Button Condition & Jasmine update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,3 @@ before_script:
 
 script:
   - node_modules/.bin/karma start karma.conf.js --no-auto-watch --single-run --reporters=dots --browsers=Firefox
-  - node_modules/.bin/protractor e2e-tests/protractor.conf.js --browser=firefox

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Main wizard directive must be added to Ionic's ion-slide-box directive
 ```
 
 ###ion-wizard-step
-Apply this directive to an `ion-slide` to define each step of the wizard. If needed, a condition can be defined which
+Apply this directive to an `ion-slide` to define each step of the wizard. If needed, a `next-condition` can be defined which
 will be evaluated before allowing the user to move forward. An event is generated if the condition fails
 that can be used to inform the user or perform any other action from the controller.
 Apply the `has-header` class to add some top padding in case there is a navigation bar.
 
 ```
-<ion-slide ion-wizard-step condition="user.LastName != undefined" class="has-header">
+<ion-slide ion-wizard-step next-condition="user.LastName != undefined" class="has-header">
     ...
 </ion-slide>
 ```
@@ -83,7 +83,7 @@ Then in your app controller:
 angular.module('myApp.controllers')
     .controller('IntroCtrl', ['$scope', '$ionicPopup', function($scope, $ionicPopup) {
         $scope.$on('wizard:StepFailed', function(e, args) {
-            if (args.index == 1) {
+            if (args.index == 1 && args.direction == "next") {
                 $ionicPopup.alert({
                     title: 'Empty field',
                     template: 'Please enter a value!'
@@ -94,6 +94,11 @@ angular.module('myApp.controllers')
         });
     }]);
 ```
+
+A `prev-condition` attribute can be defined for conditionally allowing a user to move backward in the wizard.
+It operates the same way as the `next-condition`
+
+
 
 ###ion-wizard-content
 To make the content scrollable within a particular slide wrap the content in a `ion-wizard-content` directive.

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
     "Ariel Faur <ariel.faur@gmail.com>"
   ],
   "main": "dist/ion-wizard.js",
-
   "keywords": [
     "angular",
     "ionic",
@@ -28,5 +27,8 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "resolutions": {
+    "angular": "1.3.x"
+  }
 }

--- a/example/www/js/controllers.js
+++ b/example/www/js/controllers.js
@@ -7,12 +7,22 @@ angular.module('starter.controllers', [])
 
     $scope.$on('wizard:StepFailed', function(e, args) {
         if (args.index == 1) {
+          if (args.direction === "next") {
             $ionicPopup.alert({
                 title: 'Empty field',
                 template: 'Please enter a value!'
             }).then(function (res) {
                 console.log('Field is empty');
+            });            
+          }
+
+          if (args.direction === "previous") {
+            $ionicPopup.alert({
+              title: "Field Filled",
+              template: "You've filled the field"
             });
+          }
+
         }
     });
 

--- a/example/www/templates/intro.html
+++ b/example/www/templates/intro.html
@@ -77,7 +77,7 @@
             </div>
             </ion-wizard-content>
         </ion-slide>
-        <ion-slide ion-wizard-step condition="step2.name">
+        <ion-slide ion-wizard-step next-condition="step2.name" prev-condition="!step2.name">
             <ion-wizard-content class="has-header">
             <div class="row">
                 <div class="col col-center">
@@ -94,6 +94,7 @@
                     <div class="card rounded" ng-show="step2.name">
                         <div class="item">
                             <h2 class="positive">Now you can move on! Click on the next button.</h2>
+                            <p>Previous button has now been disabled</p>
                         </div>
                     </div>
                 </div>

--- a/package.json
+++ b/package.json
@@ -9,14 +9,17 @@
     "http-server": "^0.6.1",
     "bower": "^1.3.1",
     "shelljs": "^0.2.6",
-    "karma-junit-reporter": "^0.2.2"
+    "karma-junit-reporter": "^0.2.2",
+    "karma-firefox-launcher": "^0.1.6",
+    "jasmine-node": "1.3",
+    "karma-jasmine": "0.3.6",
+    "karma-chrome-launcher": "0.2.0",
+    "jasmine-core": "2.3.4"
   },
   "scripts": {
     "postinstall": "bower install",
-
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000 -c-1",
-
     "pretest": "npm install",
     "test": "node node_modules/karma/bin/karma start karma.conf.js",
     "test-single-run": "karma start karma.conf.js  --single-run"

--- a/tests/ion-wizard_test.js
+++ b/tests/ion-wizard_test.js
@@ -18,7 +18,7 @@ describe('Unit testing wizard directives', function() {
 
         scope = $rootScope.$new();
 
-        spyOn($rootScope, '$broadcast').andCallThrough();
+        spyOn($rootScope, '$broadcast').and.callThrough();
     }));
 
     describe('Test wizard next button', function() {
@@ -43,7 +43,7 @@ describe('Unit testing wizard directives', function() {
 
         it('Should hide next button when reaching the last wizard step', function() {
 
-            spyOn($ionicSlideBoxDelegate, 'slidesCount').andReturn(3);
+            spyOn($ionicSlideBoxDelegate, 'slidesCount').and.returnValue(3);
 
             // Compile a piece of HTML containing the directive
             $compile(wrappedElement)(scope);
@@ -54,7 +54,7 @@ describe('Unit testing wizard directives', function() {
         });
 
         it('Should display next button if not the end of wizard', function() {
-            spyOn($ionicSlideBoxDelegate, 'slidesCount').andReturn(13);
+            spyOn($ionicSlideBoxDelegate, 'slidesCount').and.returnValue(13);
 
             $compile(wrappedElement)(scope);
 
@@ -163,7 +163,7 @@ describe('Unit testing wizard directives', function() {
         }));
 
         it('Should hide start button on any step but the last one', function () {
-            spyOn($ionicSlideBoxDelegate, 'slidesCount').andReturn(13);
+            spyOn($ionicSlideBoxDelegate, 'slidesCount').and.returnValue(13);
 
             $compile(wrappedElement)(scope);
 
@@ -173,7 +173,7 @@ describe('Unit testing wizard directives', function() {
         });
 
         it('Should display start button on the last step', function () {
-            spyOn($ionicSlideBoxDelegate, 'slidesCount').andReturn(13);
+            spyOn($ionicSlideBoxDelegate, 'slidesCount').and.returnValue(13);
 
             $compile(wrappedElement)(scope);
 

--- a/tests/ion-wizard_test.js
+++ b/tests/ion-wizard_test.js
@@ -117,36 +117,74 @@ describe('Unit testing wizard directives', function() {
                 return false;
             };
 
-            element = angular.element("<div ion-wizard><div ion-wizard-step condition=''>Move next</div><div ion-wizard-step condition='conditionStep2()'>Move next</div><div ion-wizard-step condition='conditionStep3()'>Move next</div></div>");
+            scope.prevConditionStep2 = function() {
+                return true;
+            };
+
+            scope.prevConditionStep3 = function() {
+                return false;
+            };
+
+            element = angular.element("<div ion-wizard><div ion-wizard-step condition=''>Move next</div><div ion-wizard-step next-condition='conditionStep2()' prev-condition='prevConditionStep2()'>Move next</div><div ion-wizard-step next-condition='conditionStep3()' prev-condition='prevConditionStep3()'>Move next</div></div>");
             $compile(element)(scope);
             scope.$digest();
             controller = element.controller('ionWizard');
         }));
 
-        it('Should pass when condition undefined on button click', function() {
-            $rootScope.$broadcast('wizard:Next');
+        describe("next-condition", function() {
+            it('Should pass when condition undefined on button click', function() {
+                $rootScope.$broadcast('wizard:Next');
 
-            var conditionFn = controller.getCondition(0);
-            conditionFn().then(function(result) {
-                expect(result).toBeTruthy(); // first condition is undefined
+                var conditionFn = controller.getCondition(0);
+                conditionFn.next().then(function(result) {
+                    expect(result).toBeTruthy(); // first condition is undefined
+                });
+            });
+
+            it('Should pass when condition is defined and truthy on button click', function() {
+                $rootScope.$broadcast('wizard:Next');
+
+                var conditionFn = controller.getCondition(1);
+                conditionFn.next().then(function(result) {
+                    expect(result).toBeTruthy(); // second condition is defined as truthy
+                });
+            });
+
+            it('Should not pass when condition is defined and falsy on button click', function() {
+                $rootScope.$broadcast('wizard:Next');
+
+                var conditionFn = controller.getCondition(2);
+                conditionFn.next().then(function(result) {
+                    expect(result).toBeFalsy(); // third condition is defined as falsyy
+                });
             });
         });
+        describe("prev-condition", function() {
+            it('Should pass when condition undefined on button click', function() {
+                $rootScope.$broadcast('wizard:Previous');
 
-        it('Should pass when condition is defined and truthy on button click', function() {
-            $rootScope.$broadcast('wizard:Next');
-
-            var conditionFn = controller.getCondition(1);
-            conditionFn().then(function(result) {
-                expect(result).toBeTruthy(); // second condition is defined as truthy
+                var conditionFn = controller.getCondition(0);
+                conditionFn.prev().then(function(result) {
+                    expect(result).toBeTruthy(); // first condition is undefined
+                });
             });
-        });
 
-        it('Should not pass when condition is defined and falsy on button click', function() {
-            $rootScope.$broadcast('wizard:Next');
+            it('Should pass when condition is defined and truthy on button click', function() {
+                $rootScope.$broadcast('wizard:Next');
 
-            var conditionFn = controller.getCondition(2);
-            conditionFn().then(function(result) {
-                expect(result).toBeFalsy(); // third condition is defined as falsyy
+                var conditionFn = controller.getCondition(1);
+                conditionFn.prev().then(function(result) {
+                    expect(result).toBeTruthy(); // second condition is defined as truthy
+                });
+            });
+
+            it('Should not pass when condition is defined and falsy on button click', function() {
+                $rootScope.$broadcast('wizard:Next');
+
+                var conditionFn = controller.getCondition(2);
+                conditionFn.prev().then(function(result) {
+                    expect(result).toBeFalsy(); // third condition is defined as falsyy
+                });
             });
         });
     });


### PR DESCRIPTION
The previous button can now have a condition similar to the next button condition

In the markup, conditions are set by using `next-condition` and `prev-condition` e.g.

```
<ion-slide ion-wizard-step next-condition="nextCondition" prev-condition="previousCondition">
```

The **wizard:StepFailed** event now sends the attempted direction e.g. **next** or **previous**

I've updated the example, readme, and tests to reflect this.

[Passing build on Travis](https://travis-ci.org/dbartel/ionic-wizard)

I also updated the tests to use Jasmine 2, and updated the package.json to pull in all the testing frameworks used.

