### PR TITLE
Disable buttons when a condition fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,32 +67,13 @@ Main wizard directive must be added to Ionic's ion-slide-box directive
 
 ###ion-wizard-step
 Apply this directive to an `ion-slide` to define each step of the wizard. If needed, a `next-condition` can be defined which
-will be evaluated before allowing the user to move forward. An event is generated if the condition fails
-that can be used to inform the user or perform any other action from the controller.
+will be evaluated before allowing the user to move forward. The next button will be disabled until the condition is fulfilled.
 Apply the `has-header` class to add some top padding in case there is a navigation bar.
 
 ```
 <ion-slide ion-wizard-step next-condition="user.LastName != undefined" class="has-header">
     ...
 </ion-slide>
-```
-
-Then in your app controller:
-
-```
-angular.module('myApp.controllers')
-    .controller('IntroCtrl', ['$scope', '$ionicPopup', function($scope, $ionicPopup) {
-        $scope.$on('wizard:StepFailed', function(e, args) {
-            if (args.index == 1 && args.direction == "next") {
-                $ionicPopup.alert({
-                    title: 'Empty field',
-                    template: 'Please enter a value!'
-                }).then(function (res) {
-                    console.log('Field is empty');
-                });
-            }
-        });
-    }]);
 ```
 
 A `prev-condition` attribute can be defined for conditionally allowing a user to move backward in the wizard.

--- a/dist/ion-wizard.js
+++ b/dist/ion-wizard.js
@@ -37,21 +37,10 @@ angular.module('ionic.wizard', [])
                 element.css('height', '100%');
 
                 scope.$on("wizard:Previous", function() {
-                    if (controller.checkPreviousCondition(currentIndex)) {
-                        $ionicSlideBoxDelegate.previous();
-                    }
-                    else {
-                        $rootScope.$broadcast("wizard:StepFailed", {index: currentIndex, direction: "previous"});
-                    }
+                    $ionicSlideBoxDelegate.previous();
                 });
                 scope.$on("wizard:Next", function() {
-
-                    if (controller.checkNextCondition(currentIndex)) {
-                        $ionicSlideBoxDelegate.next();
-                    }
-                    else {
-                         $rootScope.$broadcast("wizard:StepFailed", {index: currentIndex, direction: "next"});
-                    }
+                    $ionicSlideBoxDelegate.next();
                 });
 
                 scope.$watch(function() {

--- a/dist/ion-wizard.js
+++ b/dist/ion-wizard.js
@@ -43,6 +43,7 @@ angular.module('ionic.wizard', [])
                     $ionicSlideBoxDelegate.next();
                 });
 
+                // watch the current index's condition for changes and broadcast the new condition state on change
                 scope.$watch(function() {
                     return controller.checkNextCondition(currentIndex) && controller.checkPreviousCondition(currentIndex);
                 }, function() {
@@ -67,6 +68,7 @@ angular.module('ionic.wizard', [])
             require: '^^ionWizard',
             link: function(scope, element, attrs, controller) {
                 var nextFn = function() {
+                    // if there's no condition, just set the condition to true, otherwise evaluate
                     return angular.isUndefined(attrs.nextCondition)
                         ? true
                         : scope.nextConditionFn();
@@ -119,7 +121,6 @@ angular.module('ionic.wizard', [])
                 });
 
                 scope.$on("slideBox.slideChanged", function(e, index) {
-                    element.addClass("ng-disabled");
                     element.toggleClass('ng-hide', index == $ionicSlideBoxDelegate.slidesCount() - 1);
                 });
 

--- a/dist/ion-wizard.js
+++ b/dist/ion-wizard.js
@@ -54,6 +54,13 @@ angular.module('ionic.wizard', [])
                     }
                 });
 
+                scope.$watch(function() {
+                    return controller.checkNextCondition(currentIndex) && controller.checkPreviousCondition(currentIndex);
+                }, function() {
+                    $rootScope.$broadcast("wizard:NextCondition", controller.checkNextCondition(currentIndex));
+                    $rootScope.$broadcast("wizard:PreviousCondition", controller.checkPreviousCondition(currentIndex));                    
+                });
+
                 scope.$on("slideBox.slideChanged", function(e, index) {
                     currentIndex = index;
                 });
@@ -106,6 +113,10 @@ angular.module('ionic.wizard', [])
                 scope.$on("slideBox.slideChanged", function(e, index) {
                     element.toggleClass('ng-hide', index == 0);
                 });
+                
+                scope.$on("wizard:PreviousCondition", function(e, condition) {
+                    element.attr("disabled", !condition);
+                });
             }
         }
     }])
@@ -121,6 +132,10 @@ angular.module('ionic.wizard', [])
                 scope.$on("slideBox.slideChanged", function(e, index) {
                     element.addClass("ng-disabled");
                     element.toggleClass('ng-hide', index == $ionicSlideBoxDelegate.slidesCount() - 1);
+                });
+
+                scope.$on("wizard:NextCondition", function(e, condition) {
+                    element.attr("disabled", !condition); 
                 });
             }
         }

--- a/example/www/js/controllers.js
+++ b/example/www/js/controllers.js
@@ -4,28 +4,6 @@ angular.module('starter.controllers', [])
     $scope.start = function() {
         $state.go('tab.dash');
     };
-
-    $scope.$on('wizard:StepFailed', function(e, args) {
-        if (args.index == 1) {
-          if (args.direction === "next") {
-            $ionicPopup.alert({
-                title: 'Empty field',
-                template: 'Please enter a value!'
-            }).then(function (res) {
-                console.log('Field is empty');
-            });            
-          }
-
-          if (args.direction === "previous") {
-            $ionicPopup.alert({
-              title: "Field Filled",
-              template: "You've filled the field"
-            });
-          }
-
-        }
-    });
-
 }])
 
 .controller('DashCtrl', function($scope) {})

--- a/example/www/js/ion-wizard.js
+++ b/example/www/js/ion-wizard.js
@@ -16,6 +16,18 @@ angular.module('ionic.wizard', [])
                     return conditions[index];
                 };
 
+                this.checkNextCondition = function(index) {
+                    return index > (conditions.length - 1)
+                        ? false
+                        : conditions[index].next();
+                };
+
+                this.checkPreviousCondition = function(index) {
+                    return index > (conditions.length - 1)
+                        ? false
+                        : conditions[index].prev();
+                };
+
             }],
             link: function (scope, element, attrs, controller) {
                 var currentIndex = 0;
@@ -25,21 +37,17 @@ angular.module('ionic.wizard', [])
                 element.css('height', '100%');
 
                 scope.$on("wizard:Previous", function() {
-                    var fn = controller.getCondition(currentIndex);
-
-                    fn.prev().then(function () {
-                        $ionicSlideBoxDelegate.previous();
-                    }, function () {
-                        $rootScope.$broadcast("wizard:StepFailed", {index: currentIndex, direction: "previous"});
-                    });
+                    $ionicSlideBoxDelegate.previous();
                 });
                 scope.$on("wizard:Next", function() {
-                    var fn = controller.getCondition(currentIndex);
-                    fn.next().then(function () {
-                        $ionicSlideBoxDelegate.next();
-                    }, function () {
-                        $rootScope.$broadcast("wizard:StepFailed", {index: currentIndex, direction: "next"});
-                    })
+                    $ionicSlideBoxDelegate.next();
+                });
+
+                scope.$watch(function() {
+                    return controller.checkNextCondition(currentIndex) && controller.checkPreviousCondition(currentIndex);
+                }, function() {
+                    $rootScope.$broadcast("wizard:NextCondition", controller.checkNextCondition(currentIndex));
+                    $rootScope.$broadcast("wizard:PreviousCondition", controller.checkPreviousCondition(currentIndex));                    
                 });
 
                 scope.$on("slideBox.slideChanged", function(e, index) {
@@ -59,41 +67,21 @@ angular.module('ionic.wizard', [])
             require: '^^ionWizard',
             link: function(scope, element, attrs, controller) {
                 var nextFn = function() {
-                    var deferred  = $q.defer();
-
-                    if (angular.isUndefined(attrs.nextCondition)) {
-                        deferred.resolve();
-                    } else {
-                        if (scope.nextConditionFn()) {
-                            deferred.resolve();
-                        } else {
-                            deferred.reject();
-                        }
-                    }
-
-                    return deferred.promise;
+                    return angular.isUndefined(attrs.nextCondition)
+                        ? true
+                        : scope.nextConditionFn();
                 };
 
                 var prevFn = function() {
-                    var deferred  = $q.defer();
-
-                    if (angular.isUndefined(attrs.prevCondition)) {
-                        deferred.resolve();
-                    } else {
-                        if (scope.prevConditionFn()) {
-                            deferred.resolve();
-                        } else {
-                            deferred.reject();
-                        }
-                    }
-
-                    return deferred.promise;
+                    return angular.isUndefined(attrs.prevCondition)
+                        ? true
+                        : scope.prevConditionFn();
                 };
 
                 var conditions = {
                     next: nextFn,
                     prev: prevFn
-                }
+                };
 
                 controller.addCondition(conditions);
             }
@@ -114,6 +102,10 @@ angular.module('ionic.wizard', [])
                 scope.$on("slideBox.slideChanged", function(e, index) {
                     element.toggleClass('ng-hide', index == 0);
                 });
+                
+                scope.$on("wizard:PreviousCondition", function(e, condition) {
+                    element.attr("disabled", !condition);
+                });
             }
         }
     }])
@@ -127,7 +119,12 @@ angular.module('ionic.wizard', [])
                 });
 
                 scope.$on("slideBox.slideChanged", function(e, index) {
+                    element.addClass("ng-disabled");
                     element.toggleClass('ng-hide', index == $ionicSlideBoxDelegate.slidesCount() - 1);
+                });
+
+                scope.$on("wizard:NextCondition", function(e, condition) {
+                    element.attr("disabled", !condition); 
                 });
             }
         }
@@ -140,6 +137,8 @@ angular.module('ionic.wizard', [])
             },
             link: function(scope, element) {
                 element.addClass('ng-hide');
+
+                
 
                 element.on('click', function() {
                     scope.startFn();

--- a/example/www/js/ion-wizard.js
+++ b/example/www/js/ion-wizard.js
@@ -43,6 +43,7 @@ angular.module('ionic.wizard', [])
                     $ionicSlideBoxDelegate.next();
                 });
 
+                // watch the current index's condition for changes and broadcast the new condition state on change
                 scope.$watch(function() {
                     return controller.checkNextCondition(currentIndex) && controller.checkPreviousCondition(currentIndex);
                 }, function() {
@@ -67,6 +68,7 @@ angular.module('ionic.wizard', [])
             require: '^^ionWizard',
             link: function(scope, element, attrs, controller) {
                 var nextFn = function() {
+                    // if there's no condition, just set the condition to true, otherwise evaluate
                     return angular.isUndefined(attrs.nextCondition)
                         ? true
                         : scope.nextConditionFn();
@@ -119,7 +121,6 @@ angular.module('ionic.wizard', [])
                 });
 
                 scope.$on("slideBox.slideChanged", function(e, index) {
-                    element.addClass("ng-disabled");
                     element.toggleClass('ng-hide', index == $ionicSlideBoxDelegate.slidesCount() - 1);
                 });
 

--- a/example/www/templates/intro.html
+++ b/example/www/templates/intro.html
@@ -91,10 +91,14 @@
             </div>
             <div class="row">
                 <div class="col col-center">
+                    <div class="card rounded" ng-hide="step2.name">
+                        <div class="item">
+                            <h2 class="positive">The next button has been disabled until the input is filled</h2>
+                        </div>
+                    </div>
                     <div class="card rounded" ng-show="step2.name">
                         <div class="item">
-                            <h2 class="positive">Now you can move on! Click on the next button.</h2>
-                            <p>Previous button has now been disabled</p>
+                            <h2 class="positive">Now you can move on! Click on the next button. The previous button has now been disabled</h2>
                         </div>
                     </div>
                 </div>

--- a/tests/ion-wizard_test.js
+++ b/tests/ion-wizard_test.js
@@ -105,80 +105,143 @@ describe('Unit testing wizard directives', function() {
 
 
     describe('Test wizard directive', function() {
-        var element, controller, $ionicSlideBoxDelegate;
+        var element, controller, $ionicSlideBoxDelegate, nextButtonElement, prevButtonElement;
 
-        beforeEach(inject(function(_$ionicSlideBoxDelegate_) {
-            $ionicSlideBoxDelegate = _$ionicSlideBoxDelegate_;
+        var injectDirectives = function injectDirectives(condition) {
+            inject(function(_$ionicSlideBoxDelegate_) {
 
-            scope.conditionStep2 = function() {
-                return true;
-            };
-            scope.conditionStep3 = function() {
-                return false;
-            };
+                if (condition === undefined) {
+                    // no conditions
+                    element = angular.element("<div ion-wizard><div ion-wizard-step >Move next</div> \
+                        <div ion-wizard-step >Move next</div> \
+                        </div>"
+                    );
 
-            scope.prevConditionStep2 = function() {
-                return true;
-            };
+                }
+                else {
+                    scope.nextConditionFn = function() {
+                        return condition;
+                    };
 
-            scope.prevConditionStep3 = function() {
-                return false;
-            };
+                    scope.prevConditionFn = function() {
+                        return condition;
+                    };
 
-            element = angular.element("<div ion-wizard><div ion-wizard-step condition=''>Move next</div><div ion-wizard-step next-condition='conditionStep2()' prev-condition='prevConditionStep2()'>Move next</div><div ion-wizard-step next-condition='conditionStep3()' prev-condition='prevConditionStep3()'>Move next</div></div>");
-            $compile(element)(scope);
-            scope.$digest();
-            controller = element.controller('ionWizard');
-        }));
+                    element = angular.element("<div ion-wizard><div ion-wizard-step next-condition='nextConditionFn()' prev-condition='prevConditionFn()'>Move next</div> \
+                        <div ion-wizard-step >Move next</div> \
+                        </div>"
+                    );
+                }
+                prevButtonElement = angular.element("<button ion-wizard-previous>Previous</button>");
+                nextButtonElement = angular.element("<button ion-wizard-next>Next</button>");    
+          
+                $compile(element)(scope);
+                $compile(prevButtonElement)(scope);
+                $compile(nextButtonElement)(scope);
+                scope.$digest();
+                controller = element.controller('ionWizard');
+
+            });
+        }
 
         describe("next-condition", function() {
-            it('Should pass when condition undefined on button click', function() {
-                $rootScope.$broadcast('wizard:Next');
+            describe("for an undefined condition", function() {
+                beforeEach(function() {
+                    injectDirectives(undefined);
+                });
 
-                var conditionFn = controller.getCondition(0);
-                var result = conditionFn.next();
-                expect(result).toBeTruthy(); // first condition is undefined
+                it("should pass", function() {
+                    var condition = controller.checkNextCondition(0);
+                    expect(condition).toBeTruthy();
+                });
+
+                it("should enable the next button", function() {
+                    var buttonDisabled = nextButtonElement.attr("disabled");
+                    expect(buttonDisabled).toBeFalsy();
+                });
             });
 
-            it('Should pass when condition is defined and truthy on button click', function() {
-                $rootScope.$broadcast('wizard:Next');
+            describe("for a true condition", function() {
+                beforeEach(function() {
+                    injectDirectives(true);
+                });
 
-                var conditionFn = controller.getCondition(1);
-                var result = conditionFn.next();
-                expect(result).toBeTruthy(); // second condition is defined as truthy
+                it("should pass", function() {
+                    var condition = controller.checkNextCondition(0);
+                    expect(condition).toBeTruthy();
+                });
+
+                it("should enable the next button", function() {
+                    var buttonDisabled = nextButtonElement.attr("disabled");
+                    expect(buttonDisabled).toBeFalsy();
+                });
             });
 
-            it('Should not pass when condition is defined and falsy on button click', function() {
-                $rootScope.$broadcast('wizard:Next');
-                var conditionFn = controller.getCondition(2);
-                var result = conditionFn.next();
-                expect(result).toBeFalsy(); // third condition is defined as falsyy
+            describe("for a false condition", function() {
+                beforeEach(function() {
+                    injectDirectives(false);
+                });
+
+                it("should fail", function() {
+                    var condition = controller.checkNextCondition(0);
+                    expect(condition).toBeFalsy();
+                });
+
+                it("should disable the next button", function() {
+                    var buttonDisabled = nextButtonElement.attr("disabled");
+                    expect(buttonDisabled).toBeTruthy();
+                });
             });
         });
         describe("prev-condition", function() {
-            it('Should pass when condition undefined on button click', function() {
-                $rootScope.$broadcast('wizard:Previous');
+            describe("for an undefined condition", function() {
+                beforeEach(function() {
+                    injectDirectives(undefined);
+                });
 
-                var conditionFn = controller.getCondition(0);
-                var result = conditionFn.prev();
-                expect(result).toBeTruthy(); // first condition is undefined
+                it("should pass", function() {
+                    var condition = controller.checkPreviousCondition(0);
+                    expect(condition).toBeTruthy();
+                });
+
+                it("should enable the next button", function() {
+                    var buttonDisabled = prevButtonElement.attr("disabled");
+                    expect(buttonDisabled).toBeFalsy();
+                });
             });
 
-            it('Should pass when condition is defined and truthy on button click', function() {
-                $rootScope.$broadcast('wizard:Previous');
+            describe("for a true condition", function() {
+                beforeEach(function() {
+                    injectDirectives(true);
+                });
 
-                var conditionFn = controller.getCondition(1);
-                var result = conditionFn.prev();
-                expect(result).toBeTruthy(); // second condition is defined as truthy
+                it("should pass", function() {
+                    var condition = controller.checkPreviousCondition(0);
+                    expect(condition).toBeTruthy();
+                });
+
+                it("should enable the next button", function() {
+                    var buttonDisabled = prevButtonElement.attr("disabled");
+                    expect(buttonDisabled).toBeFalsy();
+                });
             });
 
-            it('Should not pass when condition is defined and falsy on button click', function() {
-                $rootScope.$broadcast('wizard:Previous');
+            describe("for a false condition", function() {
+                beforeEach(function() {
+                    injectDirectives(false);
+                });
 
-                var conditionFn = controller.getCondition(2);
-                var result  = conditionFn.prev();
-                expect(result).toBeFalsy(); // third condition is defined as falsey
+                it("should fail", function() {
+                    var condition = controller.checkPreviousCondition(0);
+                    expect(condition).toBeFalsy();                    
+                });
+
+                it("should disable the next button", function() {
+                    var buttonDisabled = prevButtonElement.attr("disabled");
+                    expect(buttonDisabled).toBeTruthy();
+                });
             });
+
         });
     });
 

--- a/tests/ion-wizard_test.js
+++ b/tests/ion-wizard_test.js
@@ -136,27 +136,23 @@ describe('Unit testing wizard directives', function() {
                 $rootScope.$broadcast('wizard:Next');
 
                 var conditionFn = controller.getCondition(0);
-                conditionFn.next().then(function(result) {
-                    expect(result).toBeTruthy(); // first condition is undefined
-                });
+                var result = conditionFn.next();
+                expect(result).toBeTruthy(); // first condition is undefined
             });
 
             it('Should pass when condition is defined and truthy on button click', function() {
                 $rootScope.$broadcast('wizard:Next');
 
                 var conditionFn = controller.getCondition(1);
-                conditionFn.next().then(function(result) {
-                    expect(result).toBeTruthy(); // second condition is defined as truthy
-                });
+                var result = conditionFn.next();
+                expect(result).toBeTruthy(); // second condition is defined as truthy
             });
 
             it('Should not pass when condition is defined and falsy on button click', function() {
                 $rootScope.$broadcast('wizard:Next');
-
                 var conditionFn = controller.getCondition(2);
-                conditionFn.next().then(function(result) {
-                    expect(result).toBeFalsy(); // third condition is defined as falsyy
-                });
+                var result = conditionFn.next();
+                expect(result).toBeFalsy(); // third condition is defined as falsyy
             });
         });
         describe("prev-condition", function() {
@@ -164,27 +160,24 @@ describe('Unit testing wizard directives', function() {
                 $rootScope.$broadcast('wizard:Previous');
 
                 var conditionFn = controller.getCondition(0);
-                conditionFn.prev().then(function(result) {
-                    expect(result).toBeTruthy(); // first condition is undefined
-                });
+                var result = conditionFn.prev();
+                expect(result).toBeTruthy(); // first condition is undefined
             });
 
             it('Should pass when condition is defined and truthy on button click', function() {
-                $rootScope.$broadcast('wizard:Next');
+                $rootScope.$broadcast('wizard:Previous');
 
                 var conditionFn = controller.getCondition(1);
-                conditionFn.prev().then(function(result) {
-                    expect(result).toBeTruthy(); // second condition is defined as truthy
-                });
+                var result = conditionFn.prev();
+                expect(result).toBeTruthy(); // second condition is defined as truthy
             });
 
             it('Should not pass when condition is defined and falsy on button click', function() {
-                $rootScope.$broadcast('wizard:Next');
+                $rootScope.$broadcast('wizard:Previous');
 
                 var conditionFn = controller.getCondition(2);
-                conditionFn.prev().then(function(result) {
-                    expect(result).toBeFalsy(); // third condition is defined as falsyy
-                });
+                var result  = conditionFn.prev();
+                expect(result).toBeFalsy(); // third condition is defined as falsey
             });
         });
     });


### PR DESCRIPTION
Closes #5 

The ```ion-wizard-next``` and ```ion-wizard-previous``` buttons now become disabled when the condition is not fulfilled - you can see this on the second step of the example.

I removed the ```wizard:StepFailed``` event since it is no longer used - if you want this functionality to remain, we could make the wizard configurable either through an additional attribute or by setting up an ```ionWizardConfigProvider```

[Travis build](https://travis-ci.org/dbartel/ionic-wizard/)
